### PR TITLE
[HU-1168] Fix NPE when view is recycled

### DIFF
--- a/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
+++ b/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java
@@ -245,8 +245,6 @@ public class PDFView extends RelativeLayout {
     public PDFView(Context context, AttributeSet set) {
         super(context, set);
 
-        renderingHandlerThread = new HandlerThread("PDF renderer");
-
         if (isInEditMode()) {
             return;
         }
@@ -460,6 +458,13 @@ public class PDFView extends RelativeLayout {
             return;
         }
         animationManager.computeFling();
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        // Re initialise handler thread here since it's being set to null when onDetachedFromWindow is invoked
+        renderingHandlerThread = new HandlerThread("PDF renderer");
     }
 
     @Override
@@ -752,6 +757,11 @@ public class PDFView extends RelativeLayout {
         state = State.LOADED;
 
         this.pdfFile = pdfFile;
+
+        // Fix NPE: https://github.com/barteksc/AndroidPdfViewer/issues/991
+        if (renderingHandlerThread == null) {
+            renderingHandlerThread = new HandlerThread("PDF renderer");
+        }
 
         if (!renderingHandlerThread.isAlive()) {
             renderingHandlerThread.start();


### PR DESCRIPTION
**Issue**

When multiple PDF views are inflated in the same view say within a `ViewPager`, we end up with an NPE when accessing the `isAlive` function on the Handler thread.
https://github.com/barteksc/AndroidPdfViewer/issues?q=boolean+android.os.HandlerThread.isAlive%28%29

The issue lies [here](https://github.com/SafetyCulture/sc-android-pdf-view/blob/5d3cddfa144bc39d652dd893aaa1df8a7c4c1cfe/android-pdf-viewer/src/main/java/com/github/barteksc/pdfviewer/PDFView.java#L474) where the thread is being set to null when the view is detached and not being reinitialised again. 

This PR attempts to fix the NPE by -
- Initialise the handler thread in `onAttachedToWindow` as its being set to `null` in `onDetachedFromWindow`
- Add a null check as a safety-net before accessing `isAlive`