### PR TITLE
[EX-3253] Bump android-pdfium to 1.9.3

### DIFF
--- a/android-pdf-viewer/build.gradle
+++ b/android-pdf-viewer/build.gradle
@@ -17,5 +17,5 @@ android {
 
 dependencies {
     implementation rootProject.ext.AppCompat
-    api 'com.safetyculture.platform:android-pdfium:1.9.2'
+    api 'com.safetyculture.platform:android-pdfium:1.9.3'
 }


### PR DESCRIPTION
## Summary

- Bumps `com.safetyculture.platform:android-pdfium` from `1.9.2` to `1.9.3`

## Why

`1.9.3` migrates the library from `com.android.support:support-v4` to `androidx.collection`, removing the last legacy support library dependency. This is part of the Jetifier removal tracked in [EX-3253](https://safetyculture.atlassian.net/browse/EX-3253).

## Test plan

- [ ] CI green

[EX-3253](https://safetyculture.atlassian.net/browse/EX-3253)

[EX-3253]: https://safetyculture.atlassian.net/browse/EX-3253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EX-3253]: https://safetyculture.atlassian.net/browse/EX-3253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ